### PR TITLE
[WIP] Metadata & Fractal improvements

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do not edit - changes here will be overwritten by Copier
-_commit: v0.2.0
+_commit: v0.3.0
 _src_path: gh:fractal-analytics-platform/fractal-tasks-template
 author_email: marvin.albert@gmail.com
 author_name: Marvin Albert

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ src/fractal_ome_zarr_hcs_stitching/dev/__pycache__
 src/fractal_ome_zarr_hcs_stitching.egg-info
 tests/__pycache__
 tests/data/*
+.DS_Store
+__pycache__/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# enable pre-commit.ci at https://pre-commit.ci/
+
+repos:
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.15
+    hooks:
+      - id: validate-pyproject
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.5.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 # Required Python version and dependencies
 requires-python = ">=3.8"
 dependencies = [
-    "fractal-tasks-core == 1.0.0a1",
+    "fractal-tasks-core == 1.1.0",
     "multiview-stitcher == 0.1.7",
     "anndata",
     "ome-zarr",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,11 @@ select = [
     "TID",  # flake8-tidy-imports
 ]
 ignore = [
+    "C408", # Unnecessary `dict` call (rewrite as a literal)
+    "C416", # Unnecessary `dict` comprehension (rewrite using `dict()`)
     "D401", # First line should be in imperative mood (remove to opt in)
     "D415", # First line should end with a period (remove to opt in)
+    "D205", # 1 blank line required between summary line and description
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,28 @@
+# https://peps.python.org/pep-0517/
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+# https://hatch.pypa.io/latest/config/metadata/
+[tool.hatch.version]
+#path = "src/fractal_ome_zarr_hcs_stitching/__init__.py"
+source = "vcs"
+
+# read more about configuring hatch at:
+# https://hatch.pypa.io/latest/config/build/
+[tool.hatch.build.targets.wheel]
+only-include = ["src"]
+sources = ["src"]
+
+# Always include the __FRACTAL_MANIFEST__.json file in the package
+[tool.hatch.build]
+include = ["__FRACTAL_MANIFEST__.json"]
+
+
 # Project metadata (see https://peps.python.org/pep-0621)
 [project]
 name = "fractal-ome-zarr-hcs-stitching"
-version = "0.0.1"
+dynamic = ["version"]
 description = "Fractal task(s) for registering and fusing OME-Zarr HCS"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }
@@ -10,7 +31,7 @@ authors = [
 ]
 
 # Required Python version and dependencies
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "fractal-tasks-core == 1.1.0",
     "multiview-stitcher == 0.1.7",
@@ -22,17 +43,42 @@ dependencies = [
 # Optional dependencies (e.g. for `pip install -e ".[dev]"`, see
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies)
 [project.optional-dependencies]
-dev = ["devtools", "pytest", "requests", "build", "jsonschema"]
+dev = ["devtools", "hatch", "pytest", "requests", "jsonschema", "ruff", "pre-commit"]
 
-# Build options (see https://peps.python.org/pep-0517)
-[build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+# https://docs.astral.sh/ruff
+[tool.ruff]
+line-length = 88
+target-version = "py39"
+src = ["src"]
 
-[tool.setuptools.packages.find]
-where = ["src"]
-include = ["fractal_ome_zarr_hcs_stitching"]
+# https://docs.astral.sh/ruff/rules
+[tool.ruff.lint]
+pydocstyle = { convention = "google" }
+select = [
+    "E",    # style errors
+    "W",    # style warnings
+    "F",    # flakes
+    "D",    # pydocstyle
+    "D417", # Missing argument descriptions in Docstrings
+    "I",    # isort
+    "UP",   # pyupgrade
+    "C4",   # flake8-comprehensions
+    "B",    # flake8-bugbear
+    "A001", # flake8-builtins
+    "RUF",  # ruff-specific rules
+    "TCH",  # flake8-type-checking
+    "TID",  # flake8-tidy-imports
+]
+ignore = [
+    "D401", # First line should be in imperative mood (remove to opt in)
+    "D415", # First line should end with a period (remove to opt in)
+]
 
-# Always include the __FRACTAL_MANIFEST__.json file in the package
-[tool.setuptools.package-data]
-"*" = ["__FRACTAL_MANIFEST__.json"]
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = ["D", "S"]
+
+# https://docs.astral.sh/ruff/formatter/
+[tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = 89
+skip-magic-trailing-comma = false  # default is false

--- a/src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json
+++ b/src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json
@@ -3,6 +3,12 @@
   "task_list": [
     {
       "name": "Stitching Task",
+      "input_types": {
+        "stitched": false
+      },
+      "output_types": {
+        "stitched": true
+      },
       "executable_parallel": "stitching_task.py",
       "meta_parallel": {
         "cpus_per_task": 1,
@@ -17,17 +23,23 @@
             "type": "string",
             "description": "Absolute path to the OME-Zarr image."
           },
-          "output_group_name": {
-            "title": "Output Group Name",
-            "default": "fused",
-            "type": "string",
-            "description": "Name of the group to write the fused image to."
-          },
           "registration_channel_label": {
             "title": "Registration Channel Label",
             "default": "DAPI",
             "type": "string",
             "description": "Label of the channel to use for registration."
+          },
+          "overwrite_input": {
+            "title": "Overwrite Input",
+            "default": false,
+            "type": "boolean",
+            "description": "Whether to override the original, not stitched image with the output of this task."
+          },
+          "output_group_suffix": {
+            "title": "Output Group Suffix",
+            "default": "fused",
+            "type": "string",
+            "description": "Suffix of the new OME-Zarr image to write the fused image to."
           },
           "registration_binning_xy": {
             "title": "Registration Binning Xy",
@@ -47,7 +59,7 @@
         ],
         "additionalProperties": false
       },
-      "docs_info": "## stitching_task\nStitches FOVs from an OME-Zarr image.\n\nPerforms registration and fusion of FOVs indicated\nin the FOV_ROI_table of the OME-Zarr image. Writes the\nfused image back to a \"fused\" group in the same Zarr array.\n\nTODO:\n  - include and update output metadata / FOV ROI table\n  - test 2D / 3D\n  - how to best determine num_levels for build_pyramid?\n  - currently optimized for search first mode, need to implement\n    registration pair finding for \"grid\" (?) mode\n"
+      "docs_info": "## stitching_task\nStitches FOVs from an OME-Zarr image.\n\nPerforms registration and fusion of FOVs indicated\nin the FOV_ROI_table of the OME-Zarr image. Writes the\nfused image back to a \"fused\" group in the same Zarr array.\n\nTODO:\n  - include and update output metadata / FOV ROI table\n  - test 2D / 3D\n  - optimize for large data\n  - currently optimized for search first mode, need to implement\n    registration pair finding for \"grid\" (?) mode\n"
     }
   ],
   "has_args_schemas": true,

--- a/src/fractal_ome_zarr_hcs_stitching/__init__.py
+++ b/src/fractal_ome_zarr_hcs_stitching/__init__.py
@@ -1,6 +1,5 @@
-"""
-Fractal task(s) for registering and fusing OME-Zarr HCS
-"""
+"""Fractal task(s) for registering and fusing OME-Zarr HCS"""
+
 from importlib.metadata import PackageNotFoundError, version
 
 try:

--- a/src/fractal_ome_zarr_hcs_stitching/__init__.py
+++ b/src/fractal_ome_zarr_hcs_stitching/__init__.py
@@ -1,3 +1,9 @@
 """
 Fractal task(s) for registering and fusing OME-Zarr HCS
 """
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("fractal-ome-zarr-hcs-stitching")
+except PackageNotFoundError:
+    __version__ = "uninstalled"

--- a/src/fractal_ome_zarr_hcs_stitching/dev/create_manifest.py
+++ b/src/fractal_ome_zarr_hcs_stitching/dev/create_manifest.py
@@ -1,7 +1,7 @@
-"""
-Generate JSON schemas for task arguments afresh, and write them
+"""Generate JSON schemas for task arguments afresh, and write them
 to the package manifest.
 """
+
 from fractal_tasks_core.dev.create_manifest import create_manifest
 
 if __name__ == "__main__":

--- a/src/fractal_ome_zarr_hcs_stitching/dev/task_list.py
+++ b/src/fractal_ome_zarr_hcs_stitching/dev/task_list.py
@@ -1,3 +1,5 @@
+"""Contains the list of tasks available to fractal."""
+
 from fractal_tasks_core.dev.task_models import ParallelTask
 
 TASK_LIST = [

--- a/src/fractal_ome_zarr_hcs_stitching/dev/task_list.py
+++ b/src/fractal_ome_zarr_hcs_stitching/dev/task_list.py
@@ -3,6 +3,8 @@ from fractal_tasks_core.dev.task_models import ParallelTask
 TASK_LIST = [
     ParallelTask(
         name="Stitching Task",
+        input_types={"stitched": False},
+        output_types={"stitched": True},
         executable="stitching_task.py",
         meta={"cpus_per_task": 1, "mem": 4000},
     ),

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -15,7 +15,7 @@ from dask.diagnostics import ProgressBar
 
 import anndata as ad
 
-from pydantic.decorator import validate_arguments
+from pydantic.v1.decorator import validate_arguments
 
 from fractal_tasks_core.ngff import load_NgffImageMeta
 from fractal_tasks_core.pyramids import build_pyramid

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -1,49 +1,36 @@
-"""
-This is the Python module for sitching FOVs from an OME-Zarr image.
-"""
+"""This is the Python module for sitching FOVs from an OME-Zarr image."""
 
 import logging
-from typing import Any
 import os
-from pathlib import Path
 import shutil
-
-import zarr
-from ome_zarr import writer
-from ome_zarr.io import parse_url
-import numpy as np
-import dask.array as da
-from dask.diagnostics import ProgressBar
+from pathlib import Path
 
 import anndata as ad
-
-from pydantic.v1.decorator import validate_arguments
-
+import numpy as np
+import zarr
 from fractal_tasks_core.ngff import load_NgffImageMeta
 from fractal_tasks_core.ngff.zarr_utils import ZarrGroupNotFoundError
 from fractal_tasks_core.pyramids import build_pyramid
 from fractal_tasks_core.roi import get_single_image_ROI
 from fractal_tasks_core.tables import write_table
+from fractal_tasks_core.tasks._zarr_utils import (
+    _split_well_path_image_path,
+    _update_well_metadata,
+)
+from multiview_stitcher import fusion, msi_utils, param_utils, registration
+from multiview_stitcher import spatial_image_utils as si_utils
+from multiview_stitcher.mv_graph import NotEnoughOverlapError
+from ome_zarr import writer
+from ome_zarr.io import parse_url
+from pydantic.v1.decorator import validate_arguments
 
 from fractal_ome_zarr_hcs_stitching.utils import (
     get_sim_from_multiscales,
     get_tiles_from_sim,
 )
-from fractal_tasks_core.tasks._zarr_utils import (
-    _split_well_path_image_path,
-    _update_well_metadata,
-)
-
-from multiview_stitcher import (
-    registration,
-    fusion,
-    msi_utils,
-    param_utils
-)
-from multiview_stitcher.mv_graph import NotEnoughOverlapError
-from multiview_stitcher import spatial_image_utils as si_utils
 
 logger = logging.getLogger(__name__)
+
 
 @validate_arguments
 def stitching_task(
@@ -55,14 +42,13 @@ def stitching_task(
     registration_binning_xy: int = 1,
     registration_binning_z: int = 1,
 ) -> None:
-    """
-    Stitches FOVs from an OME-Zarr image.
+    """Stitches FOVs from an OME-Zarr image.
 
     Performs registration and fusion of FOVs indicated
     in the FOV_ROI_table of the OME-Zarr image. Writes the
     fused image back to a "fused" group in the same Zarr array.
 
-    TODO:
+    Todo:
       - include and update output metadata / FOV ROI table
       - test 2D / 3D
       - optimize for large data
@@ -72,14 +58,14 @@ def stitching_task(
     Args:
         zarr_url: Absolute path to the OME-Zarr image.
         registration_channel_label: Label of the channel to use for registration.
-        overwrite_input: Whether to override the original, not stitched image 
+        overwrite_input: Whether to override the original, not stitched image
             with the output of this task.
-        output_group_suffix: Suffix of the new OME-Zarr image to write the 
+        output_group_suffix: Suffix of the new OME-Zarr image to write the
             fused image to.
         registration_binning_xy: Binning factor for XY axes during registration.
-        registration_binning_z: Binning factor for Z axis during registration (if present).
+        registration_binning_z: Binning factor for Z axis during registration
+            (if present).
     """
-
     # Use the first of input_paths
     logging.info(f"{zarr_url=}")
 
@@ -87,60 +73,78 @@ def stitching_task(
     ngff_image_meta = load_NgffImageMeta(zarr_url)
     logger.info(f"  Axes: {ngff_image_meta.axes_names}")
     logger.info(f"  Number of pyramid levels: {ngff_image_meta.num_levels}")
-    logger.info(f"  Linear coarsening factor for YX axes: {ngff_image_meta.coarsening_xy}")
-    logger.info(f"  Full-resolution ZYX pixel sizes (micrometer):    {ngff_image_meta.get_pixel_sizes_zyx(level=0)}")
-    logger.info(f"  Coarsening-level-1 ZYX pixel sizes (micrometer): {ngff_image_meta.get_pixel_sizes_zyx(level=1)}")
+    logger.info(
+        f"Linear coarsening factor for YX axes: {ngff_image_meta.coarsening_xy}"
+    )
+    logger.info(
+        "Full-resolution ZYX pixel sizes (micrometer): "
+        f"{ngff_image_meta.get_pixel_sizes_zyx(level=0)}"
+    )
+    logger.info(
+        "  Coarsening-level-1 ZYX pixel sizes (micrometer): "
+        f"{ngff_image_meta.get_pixel_sizes_zyx(level=1)}"
+    )
 
     # Load FOVs for registration
-    xim_well = get_sim_from_multiscales(Path(zarr_url), 0) # could also be lower resolution
+    xim_well = get_sim_from_multiscales(
+        Path(zarr_url), 0
+    )  # could also be lower resolution
     fov_roi_table = ad.read_zarr(Path(zarr_url) / "tables/FOV_ROI_table").to_df()
     msims = get_tiles_from_sim(xim_well, fov_roi_table)
 
-    reg_spatial_dims = [dim for dim in msi_utils.get_sim_from_msim(msims[0]).dims
-        if dim in ['z', 'y', 'x']]
+    reg_spatial_dims = [
+        dim
+        for dim in msi_utils.get_sim_from_msim(msims[0]).dims
+        if dim in ["z", "y", "x"]
+    ]
 
     #############
     # Registration
     ##############
 
-    logger.info(f"Started registration")
+    logger.info("Started registration")
     logger.info(f"Registration channel: {registration_channel_label}")
     logger.info(f"Registration binning XY: {registration_binning_xy}")
     logger.info(f"Registration binning Z: {registration_binning_z}")
     logger.info(f"Registration spatial dims: {reg_spatial_dims}")
 
-    reg_channel_index = xim_well.coords['c']\
-        .data.tolist().index(registration_channel_label)
+    reg_channel_index = (
+        xim_well.coords["c"].data.tolist().index(registration_channel_label)
+    )
     try:
-        fusion_transform_key = 'translation_registered'
+        fusion_transform_key = "translation_registered"
         params = registration.register(
             msims[:],
-            transform_key='fractal_original',
+            transform_key="fractal_original",
             reg_channel_index=reg_channel_index,
             new_transform_key=fusion_transform_key,
             registration_binning={
-                'y': registration_binning_xy,
-                'x': registration_binning_xy,
-                } if 'z' not in msi_utils.get_sim_from_msim(msims[0]).dims else {
-                'z': registration_binning_z,
-                'y': registration_binning_xy,
-                'x': registration_binning_xy,
-                },
+                "y": registration_binning_xy,
+                "x": registration_binning_xy,
+            }
+            if "z" not in msi_utils.get_sim_from_msim(msims[0]).dims
+            else {
+                "z": registration_binning_z,
+                "y": registration_binning_xy,
+                "x": registration_binning_xy,
+            },
         )
     except NotEnoughOverlapError:
-        logger.warning(f"Not enough overlap for stitching.")
-        fusion_transform_key = 'fractal_original'
+        logger.warning("Not enough overlap for stitching.")
+        fusion_transform_key = "fractal_original"
 
-    logger.info(f"Finished registration")
+    logger.info("Finished registration")
 
-    shifts = {ip:
-                {dim: s for dim, s in zip(
-                    reg_spatial_dims,
-                    param_utils.translation_from_affine(p.sel(t=0).data)
-                    )
-                }
-                    for ip, p in enumerate(params)
-                    if not np.allclose(p.sel(t=0).data, np.eye(len(reg_spatial_dims) + 1))}
+    shifts = {
+        ip: {
+            dim: s
+            for dim, s in zip(
+                reg_spatial_dims, param_utils.translation_from_affine(p.sel(t=0).data)
+            )
+        }
+        for ip, p in enumerate(params)
+        if not np.allclose(p.sel(t=0).data, np.eye(len(reg_spatial_dims) + 1))
+    }
     logger.info(f"Obtained shifts: {shifts}")
 
     ########
@@ -157,12 +161,12 @@ def stitching_task(
         output_chunksize=xim_well.data.chunksize[-1],
         output_spacing=si_utils.get_spacing_from_sim(sims[0]),
         # fusion_func=fusion.max_fusion,
-        )
+    )
 
     fused = fused.sel(t=0, drop=True)
 
-    if 'z' not in fused.dims:
-        fused = fused.expand_dims('z', xim_well.dims.index('z'))
+    if "z" not in fused.dims:
+        fused = fused.expand_dims("z", xim_well.dims.index("z"))
 
     # get the dask array from the fused sim
     fused_da = fused.data
@@ -178,17 +182,18 @@ def stitching_task(
     fused_da = fused_da.to_zarr(
         f"{output_zarr_url}/0",
         overwrite=True,
-        dimension_separator='/',
+        dimension_separator="/",
         return_stored=True,
-        compute=True)
+        compute=True,
+    )
 
-    logger.info(f"Finished fusion")
+    logger.info("Finished fusion")
 
-    logger.info(f"Started building resolution pyramid")
+    logger.info("Started building resolution pyramid")
 
     # Starting from on-disk full-resolution data, build and write to disk a
     # pyramid of coarser levels
-    # Provide original chunksize to avoid "ValueError: Attempt to save array 
+    # Provide original chunksize to avoid "ValueError: Attempt to save array
     # to zarr with irregular chunking, please call `arr.rechunk(...)` first."
     build_pyramid(
         zarrurl=output_zarr_url,
@@ -206,34 +211,44 @@ def stitching_task(
         axes=ngff_image_meta.axes_names,
         datasets=[
             {
-                'path': fractal_ds.path,
-                'coordinateTransformations':
-                    [
-                        {
-                            "type": coordinateTransformation.type,
-                            "scale": coordinateTransformation.scale,
-                        }
+                "path": fractal_ds.path,
+                "coordinateTransformations": [
+                    {
+                        "type": coordinateTransformation.type,
+                        "scale": coordinateTransformation.scale,
+                    }
                     for coordinateTransformation in fractal_ds.coordinateTransformations
-                    ]
+                ],
             }
-            for fractal_ds in ngff_image_meta.multiscales[0].datasets[:ngff_image_meta.num_levels]
+            for fractal_ds in ngff_image_meta.multiscales[0].datasets[
+                : ngff_image_meta.num_levels
+            ]
         ],
-        metadata=dict(omero = dict(channels = [channel.dict() for channel in ngff_image_meta.omero.channels]))
+        metadata=dict(
+            omero=dict(
+                channels=[channel.dict() for channel in ngff_image_meta.omero.channels]
+            )
+        ),
     )
     # Workaround: Manually add wavelength_id attr back to omero channel
     original_omero_attrs = zarr.open(zarr_url).attrs["omero"]["channels"]
     for i, omero_channel in enumerate(output_group.attrs["omero"]["channels"]):
         omero_channel["wavelength_id"] = original_omero_attrs[i]["wavelength_id"]
 
-    logger.info(f"Finished building resolution pyramid")
+    logger.info("Finished building resolution pyramid")
 
     # Add ROI table to the image
     ngff_image_meta.get_pixel_sizes_zyx(level=0)
-    pixels_ZYX = ngff_image_meta.multiscales[0].datasets[0].coordinateTransformations[0].scale[-3:]
+    pixels_ZYX = (
+        ngff_image_meta.multiscales[0]
+        .datasets[0]
+        .coordinateTransformations[0]
+        .scale[-3:]
+    )
     image_ROI_table = get_single_image_ROI(fused_da.shape, pixels_ZYX=pixels_ZYX)
     write_table(
         output_group,
-        "well_ROI_table", # Could also be image_ROI_table
+        "well_ROI_table",  # Could also be image_ROI_table
         image_ROI_table,
         overwrite=True,
         table_attrs={"type": "roi_table"},
@@ -243,12 +258,10 @@ def stitching_task(
     # Clean up Zarr file
     ####################
     if overwrite_input:
-        logger.info(
-            "Replace original zarr image with the newly created Zarr image"
-        )
+        logger.info("Replace original zarr image with the newly created Zarr image")
         os.rename(zarr_url, f"{zarr_url}_tmp")
         os.rename(output_zarr_url, zarr_url)
-        shutil.rmtree(f"{zarr_url}_tmp")        
+        shutil.rmtree(f"{zarr_url}_tmp")
     else:
         image_list_updates = dict(
             image_list_updates=[dict(zarr_url=output_zarr_url, origin=zarr_url)]
@@ -273,7 +286,7 @@ def stitching_task(
 
         return image_list_updates
 
-    logger.info(f"Done stitching")
+    logger.info("Done stitching")
 
 
 if __name__ == "__main__":

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -222,8 +222,10 @@ def stitching_task(
         ],
         metadata=dict(omero = dict(channels = [channel.dict() for channel in ngff_image_meta.omero.channels]))
     )
-    # FIXME: This way of writing Omero metadata currently drops Fractal 
-    # wavelength_id entry in omero channels
+    # Workaround: Manually add wavelength_id attr back to omero channel
+    original_omero_attrs = zarr.open(zarr_url).attrs["omero"]["channels"]
+    for i, omero_channel in enumerate(output_group.attrs["omero"]["channels"]):
+        omero_channel["wavelength_id"] = original_omero_attrs[i]["wavelength_id"]
 
     logger.info(f"Finished building resolution pyramid")
 

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -21,6 +21,7 @@ from pydantic.v1.decorator import validate_arguments
 
 from fractal_tasks_core.ngff import load_NgffImageMeta
 from fractal_tasks_core.pyramids import build_pyramid
+from fractal_tasks_core.ngff.zarr_utils import ZarrGroupNotFoundError
 
 from fractal_ome_zarr_hcs_stitching.utils import (
     get_sim_from_multiscales,
@@ -242,11 +243,18 @@ def stitching_task(
         )
         # Update the metadata of the the well
         well_url, new_img_path = _split_well_path_image_path(output_zarr_url)
-        _update_well_metadata(
-            well_url=well_url,
-            old_image_path=old_img_path,
-            new_image_path=new_img_path,
-        )
+        # FIXME: Check for well existence
+        try:
+            _update_well_metadata(
+                well_url=well_url,
+                old_image_path=old_img_path,
+                new_image_path=new_img_path,
+            )
+        except ZarrGroupNotFoundError:
+            logger.debug(
+                f"{zarr_url} is not in an HCS plate. No well metadata got updated"
+            )
+
         return image_list_updates
 
     logger.info(f"Done stitching")

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -203,8 +203,6 @@ def stitching_task(
     # attach metadata to the fused image
     store = parse_url(output_zarr_url, mode="w").store
     output_group = zarr.group(store=store)
-    # FIXME: This way of writing Omero metadata currently drops Fractal 
-    # wavelength_id entry in omero channels
     writer.write_multiscales_metadata(
         group=output_group,
         axes=ngff_image_meta.axes_names,
@@ -224,6 +222,8 @@ def stitching_task(
         ],
         metadata=dict(omero = dict(channels = [channel.dict() for channel in ngff_image_meta.omero.channels]))
     )
+    # FIXME: This way of writing Omero metadata currently drops Fractal 
+    # wavelength_id entry in omero channels
 
     logger.info(f"Finished building resolution pyramid")
 
@@ -264,6 +264,11 @@ def stitching_task(
         except ZarrGroupNotFoundError:
             logger.debug(
                 f"{zarr_url} is not in an HCS plate. No well metadata got updated"
+            )
+        except ValueError:
+            logger.debug(
+                f"Could not update well metadata, likely because "
+                f" {output_zarr_url} was already listed there."
             )
 
         return image_list_updates

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -188,15 +188,13 @@ def stitching_task(
 
     # Starting from on-disk full-resolution data, build and write to disk a
     # pyramid of coarser levels
-    # How to determine number of levels and coarsening factors?
-    # `build_pyramid`` fails with certain combinations of shape and num_levels
-    # Original levels are stored in ngff_image_meta.num_levels. But 5 levels 
-    # fails on test data
-    output_num_levels = 4
+    # Provide original chunksize to avoid "ValueError: Attempt to save array 
+    # to zarr with irregular chunking, please call `arr.rechunk(...)` first."
     build_pyramid(
         zarrurl=output_zarr_url,
         overwrite=True,
-        num_levels=output_num_levels,
+        num_levels=ngff_image_meta.num_levels,
+        chunksize=xim_well.data.chunksize,
         coarsening_xy=ngff_image_meta.coarsening_xy,
     )
 
@@ -218,7 +216,7 @@ def stitching_task(
                     for coordinateTransformation in fractal_ds.coordinateTransformations
                     ]
             }
-            for fractal_ds in ngff_image_meta.multiscales[0].datasets[:output_num_levels]
+            for fractal_ds in ngff_image_meta.multiscales[0].datasets[:ngff_image_meta.num_levels]
         ],
         metadata=dict(omero = dict(channels = [channel.dict() for channel in ngff_image_meta.omero.channels]))
     )

--- a/src/fractal_ome_zarr_hcs_stitching/utils.py
+++ b/src/fractal_ome_zarr_hcs_stitching/utils.py
@@ -1,23 +1,21 @@
+"""Fractal multiview stitcher utils."""
+
 from pathlib import Path
 
-import pandas as pd
-
 import dask.array as da
-from spatial_image import to_spatial_image
-
+import pandas as pd
 from fractal_tasks_core.channels import get_omero_channel_list
 from fractal_tasks_core.ngff import load_NgffImageMeta
-
+from multiview_stitcher import msi_utils
 from multiview_stitcher import spatial_image_utils as si_utils
-from multiview_stitcher import msi_utils, param_utils
+from spatial_image import to_spatial_image
 
 
 def get_sim_from_multiscales(
     multiscales_path: Path,
     resolution: int = 0,
-    ):
-    """
-    Get a spatial image from a multiscales ngff zarr file
+):
+    """Get a spatial image from a multiscales ngff zarr file
     representing a given resolution level.
 
     Parameters
@@ -27,27 +25,26 @@ def get_sim_from_multiscales(
     resolution : int, optional
         Resolution level index, by default 0
 
-    Returns
+    Returns:
     -------
     spatial_image.SpatialImage
     """
-
     ngff_image_meta = load_NgffImageMeta(multiscales_path)
     axes = ngff_image_meta.axes_names
     spatial_dims = [dim for dim in axes if dim in ["z", "y", "x"]]
     scales = ngff_image_meta.pixel_sizes_zyx
 
-    channel_names = [oc.label
-        for oc in get_omero_channel_list(image_zarr_path=multiscales_path)]
-    
+    channel_names = [
+        oc.label for oc in get_omero_channel_list(image_zarr_path=multiscales_path)
+    ]
+
     data = da.from_zarr(f"{multiscales_path / Path(str(resolution))}")
 
     sim = to_spatial_image(
         data,
         dims=axes,
         c_coords=channel_names,
-        scale={dim: scales[resolution][idim]
-                for idim, dim in enumerate(spatial_dims)},
+        scale={dim: scales[resolution][idim] for idim, dim in enumerate(spatial_dims)},
         translation={dim: 0 for dim in spatial_dims},
     )
 
@@ -57,9 +54,8 @@ def get_sim_from_multiscales(
 def get_tiles_from_sim(
     xim_well,
     fov_roi_table: pd.DataFrame,
-    ):
-    """
-    _summary_
+):
+    """_summary_
 
     Parameters
     ----------
@@ -68,41 +64,45 @@ def get_tiles_from_sim(
     fov_roi_table : pd.DataFrame
         Table with the FOV ROIs.
 
-    Returns
+    Returns:
     -------
     list of multiscale_spatial_image (multiview-stitcher flavor)
     """
-
     input_spatial_dims = [dim for dim in xim_well.dims if dim in ["z", "y", "x"]]
     msims = []
-    for i, row in fov_roi_table.iterrows():
+    for _, row in fov_roi_table.iterrows():
+        origin = {dim: row[f"{dim}_micrometer"] for dim in input_spatial_dims}
+        extent = {dim: row[f"len_{dim}_micrometer"] for dim in input_spatial_dims}
 
-        origin = {dim: row[f'{dim}_micrometer'] for dim in input_spatial_dims}
-        extent = {dim: row[f'len_{dim}_micrometer'] for dim in input_spatial_dims}
+        origin_original = {
+            dim: row[f"{dim}_micrometer_original"] if dim != "z" else 0
+            for dim in input_spatial_dims
+        }
+        # extent_original = {
+        #     dim: row[f"len_{dim}_micrometer"] for dim in input_spatial_dims
+        # }
 
-        origin_original = {dim: row[f'{dim}_micrometer_original'] if dim != 'z' else 0 for dim in input_spatial_dims}
-        extent_original = {dim: row[f'len_{dim}_micrometer'] for dim in input_spatial_dims}
+        tile = xim_well.sel(
+            {
+                dim: slice(origin[dim], origin[dim] + extent[dim] - 1e-6)
+                for dim in input_spatial_dims
+            }
+        )
 
-        tile = xim_well.sel({dim: slice(origin[dim], origin[dim] + extent[dim] - 1e-6)
-                            for dim in input_spatial_dims})
-        
         tile = tile.squeeze(drop=True)
 
-        tile_spatial_dims = [dim for dim in tile.dims if dim in ["z", "y", "x"]]
-            
+        # tile_spatial_dims = [dim for dim in tile.dims if dim in ["z", "y", "x"]]
+
         sim = si_utils.get_sim_from_array(
             tile.data,
             dims=tile.dims,
-            c_coords=xim_well.coords['c'].data,
+            c_coords=xim_well.coords["c"].data,
             scale=si_utils.get_spacing_from_sim(tile),
             translation=origin_original,
-            transform_key='fractal_original',
+            transform_key="fractal_original",
         )
 
-        msim = msi_utils.get_msim_from_sim(
-            sim,
-            scale_factors=[]
-            )
+        msim = msi_utils.get_msim_from_sim(sim, scale_factors=[])
 
         msims.append(msim)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
-import fractal_ome_zarr_hcs_stitching
 import json
 from pathlib import Path
 
+import fractal_ome_zarr_hcs_stitching
 
 PACKAGE = "fractal_ome_zarr_hcs_stitching"
 PACKAGE_DIR = Path(fractal_ome_zarr_hcs_stitching.__file__).parent

--- a/tests/test_stitching_task.py
+++ b/tests/test_stitching_task.py
@@ -1,10 +1,10 @@
-import shutil, os
+import os
+import shutil
 from pathlib import Path
 
+import anndata as ad
 import pytest
 from devtools import debug
-
-import anndata as ad
 
 from fractal_ome_zarr_hcs_stitching.stitching_task import stitching_task
 
@@ -20,23 +20,23 @@ def test_data_dir(tmp_path: Path) -> str:
     # for testing the correctness of the stitching task in 3D.
     # Ideally, we would stream different datasets for 2D and 3D tests here.
     source_dir = (Path(__file__).parent / "data/ngff_example/my_image").as_posix()
-    # source_dir = (Path(__file__).parent / "data/240225shape_mip.zarr/A/01/0").as_posix()
-    # source_dir = (Path(__file__).parent / "data/240225shape.zarr/A/01/0").as_posix()
+    # source_dir = (Path(__file__).parent / "data/240225shape_mip.zarr/A/01/0").as_posix() #noqa E501
+    # source_dir = (Path(__file__).parent / "data/240225shape.zarr/A/01/0").as_posix() #noqa E501
 
     dest_dir = (tmp_path / "my_image").as_posix()
     # save to the same folder as the source to inspect the results
-    # dest_dir = (Path(__file__).parent / "data/ngff_example/my_image_test_copy").as_posix()
+    # dest_dir = (Path(__file__).parent / "data/ngff_example/my_image_test_copy").as_posix() #noqa E501
     # if os.path.exists(dest_dir): shutil.rmtree(dest_dir)
-    
+
     debug(source_dir, dest_dir)
     shutil.copytree(source_dir, dest_dir)
 
     # Create some overlap between the FOVs
-    fov_roi_table_path = os.path.join(dest_dir, 'tables/FOV_ROI_table')
+    fov_roi_table_path = os.path.join(dest_dir, "tables/FOV_ROI_table")
     fov_roi_table = ad.read_zarr(fov_roi_table_path)
     fov_roi_table.X[1][6] -= 7
     fov_roi_table.write_zarr(fov_roi_table_path)
-    
+
     return dest_dir
 
 
@@ -46,4 +46,4 @@ def test_stitching_task(test_data_dir):
         registration_channel_label="DAPI",
         registration_binning_xy=1,
         registration_binning_z=1,
-        )
+    )

--- a/tests/test_valid_args_schemas.py
+++ b/tests/test_valid_args_schemas.py
@@ -2,20 +2,20 @@ import json
 from pathlib import Path
 
 import pytest
-from jsonschema.validators import Draft201909Validator
-from jsonschema.validators import Draft202012Validator
-from jsonschema.validators import Draft7Validator
-
 from fractal_tasks_core.dev.lib_args_schemas import (
     create_schema_for_single_task,
 )
-from fractal_tasks_core.dev.lib_signature_constraints import _extract_function
 from fractal_tasks_core.dev.lib_signature_constraints import (
+    _extract_function,
     _validate_function_signature,
+)
+from jsonschema.validators import (
+    Draft7Validator,
+    Draft201909Validator,
+    Draft202012Validator,
 )
 
 from . import TASK_LIST
-
 
 
 def test_task_functions_have_valid_signatures():
@@ -29,8 +29,8 @@ def test_task_functions_have_valid_signatures():
                 continue
             function_name = Path(executable).with_suffix("").name
             task_function = _extract_function(
-                    executable, function_name, package_name="fractal_ome_zarr_hcs_stitching"
-                    )
+                executable, function_name, package_name="fractal_ome_zarr_hcs_stitching"
+            )
             _validate_function_signature(task_function)
 
 
@@ -46,8 +46,8 @@ def test_args_schemas_are_up_to_date():
             print(f"Now handling {executable}")
             old_schema = task[f"args_schema_{kind}"]
             new_schema = create_schema_for_single_task(
-                    executable, package="fractal_ome_zarr_hcs_stitching"
-                    )
+                executable, package="fractal_ome_zarr_hcs_stitching"
+            )
             # The following step is required because some arguments may have a
             # default which has a non-JSON type (e.g. a tuple), which we need
             # to convert to JSON type (i.e. an array) before comparison.

--- a/tests/test_valid_manifest.py
+++ b/tests/test_valid_manifest.py
@@ -1,4 +1,5 @@
 import json
+
 import requests
 from jsonschema import validate
 

--- a/tests/test_valid_task_interface.py
+++ b/tests/test_valid_task_interface.py
@@ -28,7 +28,7 @@ def validate_command(cmd: str):
 
     # Valid stderr includes pydantic.error_wrappers.ValidationError (type
     # match between model and function, but tmp_file_args has wrong arguments)
-    assert "pydantic.error_wrappers.ValidationError" in stderr
+    assert "pydantic.v1.error_wrappers.ValidationError" in stderr
 
     # Valid stderr must include a mention of "unexpected keyword arguments",
     # because we are including some invalid arguments

--- a/tests/test_valid_task_interface.py
+++ b/tests/test_valid_task_interface.py
@@ -6,8 +6,7 @@ from subprocess import PIPE
 import pytest
 from devtools import debug
 
-from . import MANIFEST
-from . import PACKAGE_DIR
+from . import MANIFEST, PACKAGE_DIR
 
 
 def validate_command(cmd: str):
@@ -15,7 +14,7 @@ def validate_command(cmd: str):
     Run a command and make assertions on stdout, stderr, retcode.
     """
     debug(cmd)
-    result = subprocess.run(  # nosec
+    result = subprocess.run(  # nosec #noqa #UP022
         shlex_split(cmd),
         stdout=PIPE,
         stderr=PIPE,


### PR DESCRIPTION
This is a WIP PR with updates I've been working on for the fractal multiview stitcher task.

Issues I plan to tackle / have tackled:

- [ ]  Omero metadata: Core Omero metadata is in place, but 2 issues remain
    1. wavelength_id? Not a standard omero key and thus gets ignored with ome-zarr-py writing of omero metadata
    2. **Why does channel order get inverted in the fused zarr??**
- [x]  Placement of output OME-Zarr image
- [x]  Option to delete old image
- [x]  Telling Fractal server about the new image
- [x]  Update to newer fractal-tasks-core version
- [x]  Copy over & adjust ROI tables? Create at least a whole well ROI table
- [x]  Figure out why orginal num_levels fails: 4 works, 5 fails
- [ ]  Test whether logger is working: Doesn't log to console when importing the Python function. Does it work in a Fractal context?
- [x] Update the manifest to handle new task arguments
- [x] Update the manifest to have input & output types
- [ ] Make well metadata update more flexible: 
     - [x] Don't assume well is present (currently makes tests fail)
     - [x] Allow overwrite of existing output in well metadata

Testing required:

- [ ] Also test with 3D data
- [ ] Add specific tests? Is public test data relevant for this?


Issues not tackled by this PR:

- 3D fusion artefacts described by @nrepina: it seems that each saved slice is some sort of projection of a few z-slices
- Semaphore issues @nrepina hit locally (currently can't reproduce those)