### PR TITLE
Add new registration features: registration on projections and user defined resolution levels. Also channel order fix.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ authors = [
 requires-python = ">=3.9"
 dependencies = [
     "fractal-tasks-core == 1.1.0",
-    "multiview-stitcher == 0.1.7",
+    "multiview-stitcher == 0.1.9",
     "anndata",
     "ome-zarr",
     "spatial_image == 0.3.0",

--- a/src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json
+++ b/src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json
@@ -41,17 +41,11 @@
             "type": "string",
             "description": "Suffix of the new OME-Zarr image to write the fused image to."
           },
-          "registration_binning_xy": {
-            "title": "Registration Binning Xy",
-            "default": 1,
+          "registration_resolution_level": {
+            "title": "Registration Resolution Level",
+            "default": 0,
             "type": "integer",
-            "description": "Binning factor for XY axes during registration."
-          },
-          "registration_binning_z": {
-            "title": "Registration Binning Z",
-            "default": 1,
-            "type": "integer",
-            "description": "Binning factor for Z axis during registration (if present)."
+            "description": "Resolution level to use for registration."
           }
         },
         "required": [

--- a/src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json
+++ b/src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json
@@ -46,6 +46,12 @@
             "default": 0,
             "type": "integer",
             "description": "Resolution level to use for registration."
+          },
+          "registration_on_z_proj": {
+            "title": "Registration On Z Proj",
+            "default": false,
+            "type": "boolean",
+            "description": "Whether to perform registration on maximum projection along z in case of 3D input data."
           }
         },
         "required": [

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -106,8 +106,6 @@ def stitching_task(
 
     if reg_max_project_z:
         xim_well_reg = xim_well_reg.max("z")
-    else:
-        xim_well_reg = xim_well_reg
 
     msims_reg = get_tiles_from_sim(
         xim_well_reg, fov_roi_table, transform_key=input_transform_key
@@ -187,7 +185,6 @@ def stitching_task(
             msims_fusion[itile], affine, fusion_transform_key
         )
 
-    # FIXME: Something in the fusion changes channel index order. Unclear what
     sims = [msi_utils.get_sim_from_msim(msim) for msim in msims_fusion]
 
     logger.info(f"Started fusion using transform key {fusion_transform_key}")

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -205,7 +205,7 @@ def stitching_task(
         fused = fused.expand_dims("z", xim_well.dims.index("z"))
 
     # get the dask array from the fused sim
-    fused_da = fused.data
+    fused_da = fused.sel({"c": fused.coords["c"].values}).data
 
     # rechunk the fused array to match the original array
     fused_da = fused_da.rechunk(xim_well.data.chunksize)

--- a/src/fractal_ome_zarr_hcs_stitching/utils.py
+++ b/src/fractal_ome_zarr_hcs_stitching/utils.py
@@ -54,6 +54,7 @@ def get_sim_from_multiscales(
 def get_tiles_from_sim(
     xim_well,
     fov_roi_table: pd.DataFrame,
+    transform_key: str = "fractal_input",
 ):
     """_summary_
 
@@ -78,9 +79,6 @@ def get_tiles_from_sim(
             dim: row[f"{dim}_micrometer_original"] if dim != "z" else 0
             for dim in input_spatial_dims
         }
-        # extent_original = {
-        #     dim: row[f"len_{dim}_micrometer"] for dim in input_spatial_dims
-        # }
 
         tile = xim_well.sel(
             {
@@ -91,15 +89,13 @@ def get_tiles_from_sim(
 
         tile = tile.squeeze(drop=True)
 
-        # tile_spatial_dims = [dim for dim in tile.dims if dim in ["z", "y", "x"]]
-
         sim = si_utils.get_sim_from_array(
             tile.data,
             dims=tile.dims,
             c_coords=xim_well.coords["c"].data,
             scale=si_utils.get_spacing_from_sim(tile),
             translation=origin_original,
-            transform_key="fractal_original",
+            transform_key=transform_key,
         )
 
         msim = msi_utils.get_msim_from_sim(sim, scale_factors=[])

--- a/tests/test_stitching_task.py
+++ b/tests/test_stitching_task.py
@@ -41,10 +41,12 @@ def test_data_dir(tmp_path: Path) -> str:
 
 
 @pytest.mark.parametrize(
-    "registration_resolution_level",
-    [0, 1],
+    "registration_resolution_level, registration_on_z_proj",
+    [[res_level, z_proj] for res_level in [0, 1] for z_proj in [True, False]],
 )
-def test_stitching_task(registration_resolution_level, test_data_dir):
+def test_stitching_task(
+    test_data_dir, registration_resolution_level, registration_on_z_proj
+):
     stitching_task(
         zarr_url=test_data_dir,
         registration_channel_label="DAPI",

--- a/tests/test_stitching_task.py
+++ b/tests/test_stitching_task.py
@@ -40,10 +40,13 @@ def test_data_dir(tmp_path: Path) -> str:
     return dest_dir
 
 
-def test_stitching_task(test_data_dir):
+@pytest.mark.parametrize(
+    "registration_resolution_level",
+    [0, 1],
+)
+def test_stitching_task(registration_resolution_level, test_data_dir):
     stitching_task(
         zarr_url=test_data_dir,
         registration_channel_label="DAPI",
-        registration_binning_xy=1,
-        registration_binning_z=1,
+        registration_resolution_level=registration_resolution_level,
     )


### PR DESCRIPTION
This PR adds the registration features described in
- #6 
- #5

It also fixes #7 by ensuring the right channel order when retrieving the dask array from the `xarray` based output of `multiview-stitcher`.

@jluethi @nrepina feel free to suggest other parameter names of the new features in case you find these inconvenient!