### PR TITLE
Pin multiview-stitcher to 0.1.10 with fixed logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ authors = [
 requires-python = ">=3.9"
 dependencies = [
     "fractal-tasks-core == 1.1.0",
-    "multiview-stitcher == 0.1.9",
+    "multiview-stitcher == 0.1.10",
     "anndata",
     "ome-zarr",
     "spatial_image == 0.3.0",


### PR DESCRIPTION
This PR closes #11 by pinning a new `multiview-stitcher` release which should no longer hijack the root logger (which occurs within `Geometry3d`).

Could you confirm the logging issue is fixed with this PR @jluethi?