### PR TITLE
[WIP] 4 add test data

### DIFF
--- a/.github/workflows/ci_pip.yml
+++ b/.github/workflows/ci_pip.yml
@@ -88,20 +88,28 @@ jobs:
         run: find . -name ".coverage*"
 
       # Run coverage generation again
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ".[dev]"
-          pip install coverage
+      # - name: Install dependencies
+      #   run: |
+      #     python -m pip install --upgrade pip
+      #     pip install ".[dev]"
+      #     pip install coverage
     
-      - name: Run tests and generate coverage report
-        run: |
-          coverage run -m pytest tests
-          coverage xml
-          coverage html
+      # - name: Run tests and generate coverage report
+      #   run: |
+      #     coverage run -m pytest tests
+      #     coverage xml
+      #     coverage html
 
-      - name: List coverage files
-        run: find . -name ".coverage*"
+      # - name: List coverage files
+      #   run: find . -name ".coverage*"
+      - name: Combine coverage data
+        env:
+          COVERAGE_FILE: ./.coverage
+        run: |
+          set -x  # Enable debug mode
+          coverage combine || true  # Combine coverage files, ignore errors for debugging
+          coverage report
+          set +x  # Disable debug mode
 
       - name: Add coverage comment to Pull Requests
         id: coverage_comment
@@ -113,3 +121,5 @@ jobs:
           MINIMUM_ORANGE: 60
           ANNOTATE_MISSING_LINES: true
           ANNOTATION_TYPE: notice
+        env:
+          COVERAGE_FILE: ./.coverage

--- a/.github/workflows/ci_pip.yml
+++ b/.github/workflows/ci_pip.yml
@@ -35,7 +35,7 @@ jobs:
           cache: "pip"
 
       - name: Install package & testing extras
-        run: python -m pip install -e ".[dev]""
+        run: python -m pip install -e ".[dev]"
 
       - name: Cache Pooch folder
         id: cache-pooch-folder

--- a/.github/workflows/ci_pip.yml
+++ b/.github/workflows/ci_pip.yml
@@ -66,6 +66,8 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-22.04
+    env:
+      COVERAGE_FILE: ./.coverage
     needs: [tests]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci_pip.yml
+++ b/.github/workflows/ci_pip.yml
@@ -83,13 +83,13 @@ jobs:
           name: coverage-data
 
       - name: List coverage files
-        run: ls -R .
+        run: find . -name ".coverage*"
 
       # Run coverage generation again
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
+          pip install ".[dev]"
           pip install coverage
     
       - name: Run tests and generate coverage report
@@ -99,7 +99,7 @@ jobs:
           coverage html
 
       - name: List coverage files
-        run: ls -R .
+        run: find . -name ".coverage*"
 
       - name: Add coverage comment to Pull Requests
         id: coverage_comment

--- a/.github/workflows/ci_pip.yml
+++ b/.github/workflows/ci_pip.yml
@@ -52,10 +52,10 @@ jobs:
         run: |
           coverage run -m pytest tests -s --log-cli-level info
 
-      - name: Generate coverage report
-        run: |
-          coverage report
-          coverage xml
+      # - name: Generate coverage report
+      #   run: |
+      #     coverage report
+      #     coverage xml
 
       - name: Upload coverage data
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci_pip.yml
+++ b/.github/workflows/ci_pip.yml
@@ -1,0 +1,90 @@
+name: CI (pip)
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+
+jobs:
+
+  tests:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-latest]
+        python-version: ["3.9", "3.10", "3.11"]
+        exclude:
+          - os: macos-latest
+            python-version: '3.9'
+          - os: macos-latest
+            python-version: '3.10'
+    name: "Core, Python ${{ matrix.python-version }}, ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Install package & testing extras
+        run: python -m pip install -e ".[dev]""
+
+      - name: Cache Pooch folder
+        id: cache-pooch-folder
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pooch
+          key: pooch-cache
+
+      - name: Run tests with coverage
+        run: |
+          coverage run -m pytest tests -s --log-cli-level info
+
+      - name: Generate coverage report
+        run: |
+          coverage report
+          coverage xml
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: ".coverage*"
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-22.04
+    needs: [tests]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade coverage[toml]
+
+      - name: Download data
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-data
+
+      - name: Add coverage comment to Pull Requests
+        id: coverage_comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          MERGE_COVERAGE_FILES: true
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 60
+          ANNOTATE_MISSING_LINES: true
+          ANNOTATION_TYPE: notice

--- a/.github/workflows/ci_pip.yml
+++ b/.github/workflows/ci_pip.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 
 jobs:
 
@@ -77,6 +81,9 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: coverage-data
+
+      - name: List coverage files
+        run: ls -R .
 
       - name: Add coverage comment to Pull Requests
         id: coverage_comment

--- a/.github/workflows/ci_pip.yml
+++ b/.github/workflows/ci_pip.yml
@@ -85,6 +85,22 @@ jobs:
       - name: List coverage files
         run: ls -R .
 
+      # Run coverage generation again
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install coverage
+    
+      - name: Run tests and generate coverage report
+        run: |
+          coverage run -m pytest tests
+          coverage xml
+          coverage html
+
+      - name: List coverage files
+        run: ls -R .
+
       - name: Add coverage comment to Pull Requests
         id: coverage_comment
         uses: py-cov-action/python-coverage-comment-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ tests/__pycache__
 tests/data/*
 .DS_Store
 __pycache__/
+.coverage
+dist/
+_playground/run_example.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 # Optional dependencies (e.g. for `pip install -e ".[dev]"`, see
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies)
 [project.optional-dependencies]
-dev = ["devtools", "hatch", "pytest", "requests", "jsonschema", "ruff", "pre-commit"]
+dev = ["devtools", "hatch", "pytest", "requests", "jsonschema", "ruff", "pre-commit", "pooch", "coverage"]
 
 # https://docs.astral.sh/ruff
 [tool.ruff]


### PR DESCRIPTION
- [x]  Github action to run tests
I'm only setting up macos actions for Python 3.11 to avoid issues with macos arm machines in CI & older Python versions

- [x]  Github action logic for pooch caching
- [x] Github action for coverage reporting in PRs
This lets us keep better track of test coverage :) 

