### PR TITLE
Improved large data support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ authors = [
 requires-python = ">=3.9"
 dependencies = [
     "fractal-tasks-core == 1.2.1",
-    "multiview-stitcher == 0.1.14",
+    "multiview-stitcher == 0.1.15",
     "anndata",
     "ome-zarr",
     "spatial_image == 0.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ sources = ["src"]
 [tool.hatch.build]
 include = ["__FRACTAL_MANIFEST__.json"]
 
+# Allow direct references to other packages
+[tool.hatch.metadata]
+allow-direct-references = "true"
 
 # Project metadata (see https://peps.python.org/pep-0621)
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ authors = [
 requires-python = ">=3.9"
 dependencies = [
     "fractal-tasks-core == 1.2.1",
-    "multiview-stitcher@git+https://github.com/multiview-stitcher/multiview-stitcher.git@3d73d87b2f28f8a55e717b5a118a6b08ed783a1a",
+    "multiview-stitcher@git+https://github.com/multiview-stitcher/multiview-stitcher.git@3d5d9a306a3dad551d1bd31bf942f709696445b8",
     "anndata",
     "ome-zarr",
     "spatial_image == 0.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ authors = [
 requires-python = ">=3.9"
 dependencies = [
     "fractal-tasks-core == 1.2.1",
-    "multiview-stitcher == 0.1.10",
+    "multiview-stitcher@git+https://github.com/multiview-stitcher/multiview-stitcher.git@3d73d87b2f28f8a55e717b5a118a6b08ed783a1a",
     "anndata",
     "ome-zarr",
     "spatial_image == 0.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,6 @@ sources = ["src"]
 [tool.hatch.build]
 include = ["__FRACTAL_MANIFEST__.json"]
 
-# Allow direct references to other packages
-[tool.hatch.metadata]
-allow-direct-references = true
-
 # Project metadata (see https://peps.python.org/pep-0621)
 [project]
 name = "fractal-ome-zarr-hcs-stitching"
@@ -37,7 +33,7 @@ authors = [
 requires-python = ">=3.9"
 dependencies = [
     "fractal-tasks-core == 1.2.1",
-    "multiview-stitcher@git+https://github.com/multiview-stitcher/multiview-stitcher.git@3d5d9a306a3dad551d1bd31bf942f709696445b8",
+    "multiview-stitcher == 0.1.14",
     "anndata",
     "ome-zarr",
     "spatial_image == 0.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ include = ["__FRACTAL_MANIFEST__.json"]
 
 # Allow direct references to other packages
 [tool.hatch.metadata]
-allow-direct-references = "true"
+allow-direct-references = true
 
 # Project metadata (see https://peps.python.org/pep-0621)
 [project]

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -70,7 +70,7 @@ def stitching_task(
             projection along z in case of 3D data.
     """
     # Use the first of input_paths
-    logging.info(f"{zarr_url=}")
+    logger.info(f"{zarr_url=}")
 
     # Parse and log several NGFF-image metadata attributes
     ngff_image_meta = load_NgffImageMeta(zarr_url)
@@ -205,7 +205,7 @@ def stitching_task(
         dim: xim_well.data.chunksize[(-ndim + idim)] for idim, dim in enumerate(sdims)
     }
     logger.info(f"Output chunksize: {output_chunksize}")
-    logging.info("Started building fusion graph")
+    logger.info("Started building fusion graph")
 
     fused = fusion.fuse(
         sims,
@@ -223,19 +223,19 @@ def stitching_task(
     # get the dask array from the fused sim
     fused_da = fused.sel({"c": fused.coords["c"].values}).data
 
-    logging.info("Finished building fusion graph")
+    logger.info("Finished building fusion graph")
 
     well_url, old_img_path = _split_well_path_image_path(zarr_url)
     output_zarr_url = f"{well_url}/{zarr_url.split('/')[-1]}_{output_group_suffix}"
     logger.info(f"Output fused path: {output_zarr_url}")
 
-    logging.info("Started fusion computation")
+    logger.info("Started fusion computation")
     # Write the fused array back to the same full-resolution Zarr array
-    fused_da = fused_da.to_zarr(
+    fused_da.to_zarr(
         f"{output_zarr_url}/0",
         overwrite=True,
         dimension_separator="/",
-        return_stored=True,
+        return_stored=False,
         compute=True,
     )
 

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -229,7 +229,7 @@ def stitching_task(
     output_zarr_url = f"{well_url}/{zarr_url.split('/')[-1]}_{output_group_suffix}"
     logger.info(f"Output fused path: {output_zarr_url}")
 
-    logging.info("Starting fusion computation")
+    logging.info("Started fusion computation")
     # Write the fused array back to the same full-resolution Zarr array
     fused_da = fused_da.to_zarr(
         f"{output_zarr_url}/0",


### PR DESCRIPTION
This PR improves support for large data by

- setting the output chunksizes equal to the input chunksizes
- depending on a multiview-stitcher branch that simplifies the dask graphs produced during fusion. Currently this branch is not ready yet for a new multiview-stitcher release, that's why I'm pinning a specific commit