### PR TITLE
Update template & add task metadata

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,10 @@
 # Do not edit - changes here will be overwritten by Copier
-_commit: v0.3.0
+_commit: v0.4.2
 _src_path: gh:fractal-analytics-platform/fractal-tasks-template
 author_email: marvin.albert@gmail.com
 author_name: Marvin Albert
 package_name: fractal_ome_zarr_hcs_stitching
 project_name: fractal-ome-zarr-hcs-stitching
 project_short_description: Fractal task(s) for registering and fusing OME-Zarr HCS
-project_url: ''
+project_url: https://github.com/m-albert/fractal-ome-zarr-hcs-stitching
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,15 @@ jobs:
       - name: Install package & testing extras
         run: python -m pip install -e ".[dev]"
 
+      - name: Check if manifest has changed
+        run: |
+          if [ -n "$(git diff --exit-code ./src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json)" ]; then
+          echo "__FRACTAL_MANIFEST__.json has changed. Please run 'python src/fractal_ome_zarr_hcs_stitching/dev/create_manifest.py' and commit the changes."
+            exit 1
+          else
+            echo "__FRACTAL_MANIFEST__.json has not changed."
+          fi
+
       - name: Cache Pooch folder
         id: cache-pooch-folder
         uses: actions/cache@v4
@@ -64,3 +73,41 @@ jobs:
         with:
             name: python-coverage-comment-action
             path: python-coverage-comment-action.txt
+
+  deploy:
+    name: Deploy
+    needs: tests
+    if: success() && startsWith(github.ref, 'refs/tags/') && github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing on PyPi
+      # see https://docs.pypi.org/trusted-publishers/
+      id-token: write
+      # This permission allows writing releases
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: 👷 Build
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: 🚢 Publish to PyPI
+        # TODO remove the "if: false" line when the package is ready for pypi release
+        if: false
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: './dist/*'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,116 @@
+# Git ignored is sourced from https://github.com/pydev-guide/pyrepo-copier/blob/main/LICENSE
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+.DS_Store
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# ruff
+.ruff_cache/
+
+# IDE settings
+.vscode/
+.idea/
+
 src/fractal_ome_zarr_hcs_stitching/__pycache__
 src/fractal_ome_zarr_hcs_stitching/dev/__pycache__
 src/fractal_ome_zarr_hcs_stitching.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,18 +5,12 @@ build-backend = "hatchling.build"
 
 # https://hatch.pypa.io/latest/config/metadata/
 [tool.hatch.version]
-#path = "src/fractal_ome_zarr_hcs_stitching/__init__.py"
 source = "vcs"
 
 # read more about configuring hatch at:
 # https://hatch.pypa.io/latest/config/build/
 [tool.hatch.build.targets.wheel]
-only-include = ["src"]
-sources = ["src"]
-
-# Always include the __FRACTAL_MANIFEST__.json file in the package
-[tool.hatch.build]
-include = ["__FRACTAL_MANIFEST__.json"]
+packages = ["src/fractal_ome_zarr_hcs_stitching"]
 
 # Project metadata (see https://peps.python.org/pep-0621)
 [project]
@@ -32,7 +26,7 @@ authors = [
 # Required Python version and dependencies
 requires-python = ">=3.9"
 dependencies = [
-    "fractal-tasks-core == 1.2.1",
+    "fractal-tasks-core == 1.3.3",
     "multiview-stitcher == 0.1.15",
     "anndata",
     "ome-zarr",

--- a/src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json
+++ b/src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json
@@ -11,8 +11,12 @@
       },
       "category": "Registration",
       "tags": [
-        "Multiview Stitcher",
-        "Fusion"
+        "multiview-stitcher",
+        "Fusion",
+        "Registration",
+        "Stitching",
+        "2D",
+        "3D"
       ],
       "executable_parallel": "stitching_task.py",
       "meta_parallel": {
@@ -88,5 +92,5 @@
   ],
   "has_args_schemas": true,
   "args_schema_version": "pydantic_v2",
-  "authors": "Marvin Albert"
+  "authors": "Marvin Albert, Joel Luethi, Nicole Repina"
 }

--- a/src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json
+++ b/src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json
@@ -9,6 +9,11 @@
       "output_types": {
         "stitched": true
       },
+      "category": "Registration",
+      "tags": [
+        "Multiview Stitcher",
+        "Fusion"
+      ],
       "executable_parallel": "stitching_task.py",
       "meta_parallel": {
         "cpus_per_task": 1,
@@ -82,5 +87,6 @@
     }
   ],
   "has_args_schemas": true,
-  "args_schema_version": "pydantic_v2"
+  "args_schema_version": "pydantic_v2",
+  "authors": "Marvin Albert"
 }

--- a/src/fractal_ome_zarr_hcs_stitching/dev/create_manifest.py
+++ b/src/fractal_ome_zarr_hcs_stitching/dev/create_manifest.py
@@ -6,7 +6,7 @@ from fractal_tasks_core.dev.create_manifest import create_manifest
 
 if __name__ == "__main__":
     PACKAGE = "fractal_ome_zarr_hcs_stitching"
-    AUTHORS = "Marvin Albert"
+    AUTHORS = "Marvin Albert, Joel Lüthi, Nicole Repina"
     create_manifest(
         package=PACKAGE,
         authors=AUTHORS,

--- a/src/fractal_ome_zarr_hcs_stitching/dev/create_manifest.py
+++ b/src/fractal_ome_zarr_hcs_stitching/dev/create_manifest.py
@@ -6,7 +6,7 @@ from fractal_tasks_core.dev.create_manifest import create_manifest
 
 if __name__ == "__main__":
     PACKAGE = "fractal_ome_zarr_hcs_stitching"
-    AUTHORS = "Marvin Albert, Joel Lüthi, Nicole Repina"
+    AUTHORS = "Marvin Albert, Joel Luethi, Nicole Repina"
     create_manifest(
         package=PACKAGE,
         authors=AUTHORS,

--- a/src/fractal_ome_zarr_hcs_stitching/dev/create_manifest.py
+++ b/src/fractal_ome_zarr_hcs_stitching/dev/create_manifest.py
@@ -6,8 +6,15 @@ from fractal_tasks_core.dev.create_manifest import create_manifest
 
 if __name__ == "__main__":
     PACKAGE = "fractal_ome_zarr_hcs_stitching"
-    create_manifest(package=PACKAGE, custom_pydantic_models=[(
-        "fractal_ome_zarr_hcs_stitching",
-        "utils.py",
-        "StitchingChannelInputModel",
-    )])
+    AUTHORS = "Marvin Albert"
+    create_manifest(
+        package=PACKAGE,
+        authors=AUTHORS,
+        custom_pydantic_models=[
+            (
+                "fractal_ome_zarr_hcs_stitching",
+                "utils.py",
+                "StitchingChannelInputModel",
+            )
+        ],
+    )

--- a/src/fractal_ome_zarr_hcs_stitching/dev/task_list.py
+++ b/src/fractal_ome_zarr_hcs_stitching/dev/task_list.py
@@ -9,5 +9,7 @@ TASK_LIST = [
         output_types={"stitched": True},
         executable="stitching_task.py",
         meta={"cpus_per_task": 1, "mem": 4000},
+        category="Registration",
+        tags=["Multiview Stitcher", "Fusion"],
     ),
 ]

--- a/src/fractal_ome_zarr_hcs_stitching/dev/task_list.py
+++ b/src/fractal_ome_zarr_hcs_stitching/dev/task_list.py
@@ -10,6 +10,6 @@ TASK_LIST = [
         executable="stitching_task.py",
         meta={"cpus_per_task": 1, "mem": 4000},
         category="Registration",
-        tags=["Multiview Stitcher", "Fusion"],
+        tags=["multiview-stitcher", "Fusion", "Registration", "Stitching", "2D", "3D"],
     ),
 ]

--- a/tests/test_valid_task_interface.py
+++ b/tests/test_valid_task_interface.py
@@ -1,0 +1,60 @@
+import json
+import subprocess
+from shlex import split as shlex_split
+
+import pytest
+from devtools import debug
+
+from . import MANIFEST, PACKAGE_DIR
+
+
+def validate_command(cmd: str):
+    """
+    Run a command and make assertions on stdout, stderr, retcode.
+    """
+    debug(cmd)
+    result = subprocess.run(  # nosec
+        shlex_split(cmd),
+        capture_output=True,
+    )
+    # The command must always fail, since tmp_file_args includes invalid
+    # arguments
+    assert result.returncode == 1
+    stderr = result.stderr.decode()
+    debug(stderr)
+
+    # Valid stderr includes pydantic.v1.error_wrappers.ValidationError (type
+    # match between model and function, but tmp_file_args has wrong arguments)
+    assert "ValidationError" in stderr
+
+    # Valid stderr must include a mention of "Unexpected keyword argument",
+    # because we are including some invalid arguments
+    assert "Unexpected keyword argument" in stderr
+
+    # Invalid stderr includes ValueError
+    assert "ValueError" not in stderr
+
+
+@pytest.mark.parametrize("task", MANIFEST["task_list"])
+def test_task_interface(task, tmp_path):
+    """
+    Test that running tasks from the command line with invalid arguments leads
+    to the expected behavior.
+    """
+    tmp_file_args = str(tmp_path / "args.json")
+    tmp_file_metadiff = str(tmp_path / "metadiff.json")
+    with open(tmp_file_args, "w") as fout:
+        args = {"wrong_arg_1": 123, "wrong_arg_2": [1, 2, 3]}
+        json.dump(args, fout, indent=4)
+
+    for key in ["executable_non_parallel", "executable_parallel"]:
+        executable = task.get(key)
+        if executable is None:
+            continue
+        task_path = (PACKAGE_DIR / executable).as_posix()
+        cmd = (
+            f"python {task_path} "
+            f"--args-json {tmp_file_args} "
+            f"--out-json {tmp_file_metadiff}"
+        )
+        validate_command(cmd)


### PR DESCRIPTION
We're adding metadata to the tasks to be able to build better task interfaces. I've created this PR to show how this metadata is structured. The core fields for each task are:

1. Category: Conversion, Segmentation, Registration, Measurement, Image Processing
2. Modality: HCS, lightsheet, EM
3. Tags: Arbitrary strings that are searchable and provide info about the task

Category & Modality work by convention, but you can add new entries when useful.

Additionally, there is now an "authors" field for the whole package.

In order for the future public Fractal page to list your tasks (see https://github.com/fractal-analytics-platform/fractal-analytics-platform.github.io/issues/6), the package needs to either be on PyPI or have github releases with whl files. As part of this PR, I'm adding a Github CI that would run tests and create releases with whl files upon tags. 

This means that for releases in the future, we don't need to make our own Github releases anymore. If we tag a commit in main, the CI should do the rest for us.

Additionally, the CI includes an easy option to activate publishing to PyPI. Whenever we feel that this would be useful, we can turn it on by removing the `if false` option on the PyPI publishing in build_and_test.yml and following the setup steps here: https://github.com/fractal-analytics-platform/fractal-tasks-template/blob/main/DEVELOPERS_GUIDE.md
=> Pypi instructions: https://docs.pypi.org/trusted-publishers