### PR TITLE
Avoid writing empty chunks of fused output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         exclude:
-          - os: macos-latest
-            python-version: '3.9'
           - os: macos-latest
             python-version: '3.10'
     name: "Core, Python ${{ matrix.python-version }}, ${{ matrix.os }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ authors = [
 # Required Python version and dependencies
 requires-python = ">=3.9"
 dependencies = [
-    "fractal-tasks-core == 1.2.1",
+    "fractal-tasks-core == 1.4.1",
     "multiview-stitcher == 0.1.15",
     "anndata",
     "ome-zarr",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ authors = [
 ]
 
 # Required Python version and dependencies
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "fractal-tasks-core == 1.4.1",
     "multiview-stitcher == 0.1.15",

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -265,6 +265,7 @@ def stitching_task(
         num_levels=ngff_image_meta.num_levels,
         chunksize=xim_well.data.chunksize,
         coarsening_xy=ngff_image_meta.coarsening_xy,
+        open_array_kwargs={"write_empty_chunks": False, "fill_value": 0},
     )
 
     # attach metadata to the fused image

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -229,10 +229,22 @@ def stitching_task(
     output_zarr_url = f"{well_url}/{zarr_url.split('/')[-1]}_{output_group_suffix}"
     logger.info(f"Output fused path: {output_zarr_url}")
 
+    # Open output array. This allows setting `write_empty_chunks=True`,
+    # which cannot be passed to dask.array.to_zarr below.
+    output_zarr_arr = zarr.open(
+        f"{output_zarr_url}/0",
+        shape=fused_da.shape,
+        chunks=fused_da.chunksize,
+        dtype=fused_da.dtype,
+        write_empty_chunks=False,
+        mode="w",
+    )
+
     logger.info("Started fusion computation")
+
     # Write the fused array back to the same full-resolution Zarr array
     fused_da.to_zarr(
-        f"{output_zarr_url}/0",
+        output_zarr_arr,
         overwrite=True,
         dimension_separator="/",
         return_stored=False,

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -237,6 +237,7 @@ def stitching_task(
         chunks=fused_da.chunksize,
         dtype=fused_da.dtype,
         write_empty_chunks=False,
+        fill_value=0,
         mode="w",
     )
 


### PR DESCRIPTION
To reduce the number of files on disk, this PR leads to empty chunks of the fused output array not being written to disk.

This is currently only true for the (most relevant) lowest resolution level, as further resolutions are written by `fractal_tasks_core.pyramids.build_pyramid`, which does not expose the `zarr` option `write_empty_chunks`.