### PR TITLE
Switch to multiview-stitcher 0.1.19 and bump spatial-image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     "fractal-tasks-core == 1.4.2",
-    "multiview-stitcher == 0.1.15",
+    "multiview-stitcher == 0.1.19",
     "anndata",
     "ome-zarr",
-    "spatial_image == 0.3.0",
+    "spatial_image == 1.1.0",
     ]
 
 # Optional dependencies (e.g. for `pip install -e ".[dev]"`, see

--- a/tests/test_stitching_task_search_first.py
+++ b/tests/test_stitching_task_search_first.py
@@ -56,7 +56,7 @@ def test_stitching_3d_on_mip_search_first(
     # earlier tests that produces good fusion
     expected_shapes = [
         (2, 6, 4392, 14580),
-        (2, 6, 4391, 14588),
+        (2, 6, 4383, 14580),
     ]
     with zarr.open(f"{search_first_ome_zarr_3d}_fused", mode="r") as zarr_group:
         assert zarr_group[0].shape == expected_shapes[registration_resolution_level]


### PR DESCRIPTION
Using `multiview-stitcher=0.1.19` solves the issues with empty z planes occurring with new output chunking parameters (relevant PR [here](https://github.com/multiview-stitcher/multiview-stitcher/pull/43)).