### PR TITLE
Expose relevant options for `pre_registration_pruning_method` in task interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install package & testing extras
         run: python -m pip install -e ".[dev]"
 
+      - name: Regenerate the manifest
+        run: python src/fractal_ome_zarr_hcs_stitching/dev/create_manifest.py
+
       - name: Check if manifest has changed
         run: |
           if [ -n "$(git diff --exit-code ./src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json)" ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     "fractal-tasks-core == 1.4.2",
-    "multiview-stitcher == 0.1.15",
+    "multiview-stitcher == 0.1.19",
     "anndata",
     "ome-zarr",
-    "spatial_image == 0.3.0",
+    "spatial_image == 1.1.0",
     ]
 
 # Optional dependencies (e.g. for `pip install -e ".[dev]"`, see

--- a/src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json
+++ b/src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json
@@ -25,6 +25,15 @@
       },
       "args_schema_parallel": {
         "$defs": {
+          "PreRegistrationPruningMethod": {
+            "description": "PreRegistrationPruningMethod Enum class",
+            "enum": [
+              null,
+              "keep_axis_aligned",
+              "shortest_paths_overlap_weighted"
+            ],
+            "title": "PreRegistrationPruningMethod"
+          },
           "StitchingChannelInputModel": {
             "description": "Channel input for stitching.",
             "properties": {
@@ -78,6 +87,16 @@
             "title": "Registration On Z Proj",
             "type": "boolean",
             "description": "Whether to perform registration on a maximum projection along z in case of 3D data."
+          },
+          "pre_registration_pruning_method": {
+            "allOf": [
+              {
+                "$ref": "#/$defs/PreRegistrationPruningMethod"
+              }
+            ],
+            "default": "keep_axis_aligned",
+            "title": "Pre Registration Pruning Method",
+            "description": "Method to use for selecting a subset of all overlapping tiles for pairwise registration. By default, only lower, upper, right and left neighbors are considered. Make sure to set this parameter to NONE if pairs of tiles which deviate from this pattern need to be registered."
           }
         },
         "required": [

--- a/src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json
+++ b/src/fractal_ome_zarr_hcs_stitching/__FRACTAL_MANIFEST__.json
@@ -28,11 +28,12 @@
           "PreRegistrationPruningMethod": {
             "description": "PreRegistrationPruningMethod Enum class",
             "enum": [
-              null,
+              "no_pruning",
               "keep_axis_aligned",
               "shortest_paths_overlap_weighted"
             ],
-            "title": "PreRegistrationPruningMethod"
+            "title": "PreRegistrationPruningMethod",
+            "type": "string"
           },
           "StitchingChannelInputModel": {
             "description": "Channel input for stitching.",
@@ -96,7 +97,7 @@
             ],
             "default": "keep_axis_aligned",
             "title": "Pre Registration Pruning Method",
-            "description": "Method to use for selecting a subset of all overlapping tiles for pairwise registration. By default, only lower, upper, right and left neighbors are considered. Make sure to set this parameter to NONE if pairs of tiles which deviate from this pattern need to be registered."
+            "description": "Method to use for selecting a subset of all overlapping tiles for pairwise registration. By default, only lower, upper, right and left neighbors are considered. Set this parameter to no_pruning if pairs of tiles which deviate from this pattern need to be registered."
           }
         },
         "required": [

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -141,6 +141,7 @@ def stitching_task(
             new_transform_key=fusion_transform_key,
             reg_channel_index=reg_channel_index,
             registration_binning={dim: 1 for dim in reg_spatial_dims},
+            pre_registration_pruning_method="keep_axis_aligned",
         )
         shifts = {
             ip: {

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -72,8 +72,8 @@ def stitching_task(
             projection along z in case of 3D data.
         pre_registration_pruning_method: Method to use for selecting a subset
             of all overlapping tiles for pairwise registration. By default,
-            only lower, upper, right and left neighbors are considered. Make
-            sure to set this parameter to NONE if pairs of tiles which deviate
+            only lower, upper, right and left neighbors are considered. Set
+            this parameter to no_pruning if pairs of tiles which deviate
             from this pattern need to be registered.
     """
     # Use the first of input_paths
@@ -148,7 +148,7 @@ def stitching_task(
             new_transform_key=fusion_transform_key,
             reg_channel_index=reg_channel_index,
             registration_binning={dim: 1 for dim in reg_spatial_dims},
-            pre_registration_pruning_method=pre_registration_pruning_method.value,
+            pre_registration_pruning_method=pre_registration_pruning_method.get_pruning_method(),
         )
         shifts = {
             ip: {

--- a/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
+++ b/src/fractal_ome_zarr_hcs_stitching/stitching_task.py
@@ -25,6 +25,7 @@ from ome_zarr.io import parse_url
 from pydantic import validate_call
 
 from fractal_ome_zarr_hcs_stitching.utils import (
+    PreRegistrationPruningMethod,
     StitchingChannelInputModel,
     get_sim_from_multiscales,
     get_tiles_from_sim,
@@ -42,6 +43,7 @@ def stitching_task(
     output_group_suffix: str = "fused",
     registration_resolution_level: int = 0,
     registration_on_z_proj: bool = True,
+    pre_registration_pruning_method: PreRegistrationPruningMethod = PreRegistrationPruningMethod.KEEPAXISALIGNED,  # noqa: E501
 ) -> None:
     """Stitches FOVs from an OME-Zarr image.
 
@@ -68,6 +70,11 @@ def stitching_task(
         registration_resolution_level: Resolution level to use for registration.
         registration_on_z_proj: Whether to perform registration on a maximum
             projection along z in case of 3D data.
+        pre_registration_pruning_method: Method to use for selecting a subset
+            of all overlapping tiles for pairwise registration. By default,
+            only lower, upper, right and left neighbors are considered. Make
+            sure to set this parameter to NONE if pairs of tiles which deviate
+            from this pattern need to be registered.
     """
     # Use the first of input_paths
     logger.info(f"{zarr_url=}")
@@ -141,7 +148,7 @@ def stitching_task(
             new_transform_key=fusion_transform_key,
             reg_channel_index=reg_channel_index,
             registration_binning={dim: 1 for dim in reg_spatial_dims},
-            pre_registration_pruning_method="keep_axis_aligned",
+            pre_registration_pruning_method=pre_registration_pruning_method.value,
         )
         shifts = {
             ip: {

--- a/src/fractal_ome_zarr_hcs_stitching/utils.py
+++ b/src/fractal_ome_zarr_hcs_stitching/utils.py
@@ -146,7 +146,7 @@ class PreRegistrationPruningMethod(Enum):
     """PreRegistrationPruningMethod Enum class
 
     Attributes:
-        NONE: All overlapping tiles are used for registration.
+        NOPRUNING: All overlapping tiles are used for registration.
         KEEPAXISALIGNED: Use only orthogonal tile pairs for registration.
             This excludes diagonal tile pairs and can lead to more robust
             registration results when tiles are not positioned irregularily.
@@ -155,6 +155,15 @@ class PreRegistrationPruningMethod(Enum):
             for registration. Tile pairs with high overlaps are preferred.
     """
 
-    NONE = None
+    NOPRUNING = "no_pruning"
     KEEPAXISALIGNED = "keep_axis_aligned"
     SHORTESTPATHSOVERLAPWEIGHTED = "shortest_paths_overlap_weighted"
+
+    def get_pruning_method(self):
+        """Get the pruning method to use
+
+        Complex mapping for no pruning, see
+        https://github.com/fractal-analytics-platform/fractal-web/issues/714
+        for context. NOPRUNING should return a None, not the string.
+        """
+        return None if self == PreRegistrationPruningMethod.NOPRUNING else self.value

--- a/tests/test_stitching_task_search_first.py
+++ b/tests/test_stitching_task_search_first.py
@@ -31,7 +31,12 @@ def test_stitching_3d_search_first(
     # outputs is not very meaningful here
 
 
+@pytest.mark.parametrize(
+    "pre_registration_pruning_method",
+    ["keep_axis_aligned", "shortest_paths_overlap_weighted", "no_pruning"],
+)
 def test_stitching_3d_on_mip_search_first(
+    pre_registration_pruning_method,
     search_first_ome_zarr_3d,
     registration_resolution_level=1,
     registration_on_z_proj=True,
@@ -41,6 +46,7 @@ def test_stitching_3d_on_mip_search_first(
         channel=StitchingChannelInputModel(wavelength_id="A04_C01"),
         registration_resolution_level=registration_resolution_level,
         registration_on_z_proj=registration_on_z_proj,
+        pre_registration_pruning_method=pre_registration_pruning_method,
     )
     expected_image_list_updates = {
         "image_list_updates": [
@@ -54,12 +60,13 @@ def test_stitching_3d_on_mip_search_first(
 
     # Validate expected shape of the Zarr based on what was produced in
     # earlier tests that produces good fusion
-    expected_shapes = [
-        (2, 6, 4392, 14580),
-        (2, 6, 4383, 14580),
-    ]
+    expected_shapes = {
+        "keep_axis_aligned": (2, 6, 4383, 14580),
+        "shortest_paths_overlap_weighted": (2, 6, 4383, 14580),
+        "no_pruning": (2, 6, 4379, 14564),
+    }
     with zarr.open(f"{search_first_ome_zarr_3d}_fused", mode="r") as zarr_group:
-        assert zarr_group[0].shape == expected_shapes[registration_resolution_level]
+        assert zarr_group[0].shape == expected_shapes[pre_registration_pruning_method]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_stitching_task_search_first.py
+++ b/tests/test_stitching_task_search_first.py
@@ -56,7 +56,7 @@ def test_stitching_3d_on_mip_search_first(
     # earlier tests that produces good fusion
     expected_shapes = [
         (2, 6, 4392, 14580),
-        (2, 6, 4391, 14588),
+        (2, 6, 4383, 14580),
     ]
     with zarr.open(f"{search_first_ome_zarr_3d}_fused", mode="r") as zarr_group:
         assert zarr_group[0].shape == expected_shapes[registration_resolution_level]


### PR DESCRIPTION
Registration can yield suboptimal results when many diagonal registration pairs with low contrast overlap are registered.

I've noticed that all of the input data (used so far) consists of tiles that are placed at orthogonal angles with respect to each other. In other words, tiles within connected components of the search first scheme are placed on the vertices of regular grids.

Example:
<img width="437" alt="image" src="https://github.com/user-attachments/assets/57c0a8be-6cc2-498e-89be-6412efcfc06e" />

(tile 35 actually has no overlap with tile 29)

`multiview-stitcher=0.1.9` can make use of this fact by only keeping pairs of tiles for registration which are "axis aligned".

Applying this in the fractal stitching task `register(..., pre_registration_pruning_method="keep_axis_aligned")` leads to the same output shapes in the test datasets and significantly improves registration in further offline samples.

@nrepina Can you confirm the orthogonal arrangement is a valid assumption for your data?

If you think there are / will be cases where diagonal pairs become important we can expose this as a task parameter (e.g. "ignore_non_orthogonal_reg_pairs" with a default value of `True`).